### PR TITLE
Updates landing page

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -29,16 +29,17 @@ layout: base_layout
 
       %h3
         We are happy to announce that our next conference will take place:
+      
       %h3
         Chicago 
-        %br
+      %br
         June 15 - 17, 2016.
+      
       %br.header-break/
       %br.header-break/
 
       %h4
         Subscribe to our newsletter and stay up to date with all upcoming news on the conference and local events!
-      
 
       .newsletter-signup
         = partial "mailchimp"

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -23,19 +23,24 @@ layout: base_layout
     = image_tag image_path('2013-conf/DSC_9712_1.jpg')
   .wrap
     .copy-wrap
-      %h1
-        Write/Speak/Code Chapters
-      %h3
-        W/S/C has now expanded with chapters in Chicago, San Francisco and New York dedicated to organizing workshops and events focused on writing, speaking and coding.
-      %br.header-break/
       %h2
-        =link_to 'Chicago', 'events/chicago'
-        %i.fa.fa-star-o
-        San Francisco
-        %i.fa.fa-star-o
-        New York
+        Write/Speak/Code Conference 2016 
       %br.header-break/
+
+      %h3
+        We are happy to announce that our next conference will take place:
+      %h3
+        Chicago 
+        %br
+        June 15 - 17, 2016.
+      %br.header-break/
+      %br.header-break/
+
       %h4
-        Subscribe to our newsletter and stay up to date with all upcoming conferences and events.
+        Subscribe to our newsletter and stay up to date with all upcoming news on the conference and local events!
+      
+
       .newsletter-signup
         = partial "mailchimp"
+
+   


### PR DESCRIPTION
@rmw Added info on conference dates and location on landing page in place of chapters. The pages on SF and NYC are not up yet, just Chicago so I removed the Chi link.