### PR TITLE
Link to 2016 sponsorship page

### DIFF
--- a/source/layouts/base_layout.haml
+++ b/source/layouts/base_layout.haml
@@ -63,7 +63,7 @@
                 %a{ href:"/blog" } Blog
 
               %li.nav-link.sponsors
-                %a{ href:"/sponsor" } Sponsor
+                %a{ href:"http://2016.writespeakcode.com/sponsor" } Sponsor
 
           %div.navigation-tools
             %div.search-bar


### PR DESCRIPTION
Now that we are archiving conf sites, /sponsor will soon not be a valid link. Update the nav to link to the current 2016 sponsorship page.