### PR TITLE
Fixed the Url link of XoGroup

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -64,7 +64,7 @@
     "xogroup":
     {
       "name": "XO Group",
-      "url": "xogrp.com",
+      "url": "https://xogroupinc.com/",
       "image": "xo_group.png"
     },
     "wtm":


### PR DESCRIPTION
Changed the link of xo group to the working URL https://xogroupinc.com/